### PR TITLE
Fix either

### DIFF
--- a/src/Data/Argonaut/Encode.purs
+++ b/src/Data/Argonaut/Encode.purs
@@ -8,11 +8,11 @@ module Data.Argonaut.Encode
 import Prelude
 
 import Data.Argonaut.Core (Json(), jsonNull, fromBoolean, fromNumber, fromString, fromArray, fromObject)
-import Data.Either (Either(..))
+import Data.Either (Either(..), either)
 import Data.Foldable (foldr)
 import Data.Generic (Generic, GenericSpine(..), toSpine)
 import Data.Int (toNumber)
-import Data.List (List(), fromList)
+import Data.List (List(..), fromList)
 import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.String (fromChar)
@@ -50,8 +50,12 @@ instance encodeJsonTuple :: (EncodeJson a, EncodeJson b) => EncodeJson (Tuple a 
   encodeJson (Tuple a b) = encodeJson [encodeJson a, encodeJson b]
 
 instance encodeJsonEither :: (EncodeJson a, EncodeJson b) => EncodeJson (Either a b) where
-  encodeJson (Left a) = encodeJson a
-  encodeJson (Right b) = encodeJson b
+  encodeJson = either (obj "Left") (obj "Right")
+    where
+    obj :: forall c. (EncodeJson c) => String -> c -> Json
+    obj tag x =
+      fromObject $ SM.fromList $
+        Cons (Tuple "tag" (fromString tag)) (Cons (Tuple "value" (encodeJson x)) Nil)
 
 instance encodeJsonUnit :: EncodeJson Unit where
   encodeJson = const jsonNull

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -183,7 +183,18 @@ genericsCheck = do
                                                              }]}
 
 
+eitherCheck = do
+  log "Test EncodeJson/DecodeJson Either instance"
+  quickCheck \(x :: Either String String) ->
+    case decodeJson (encodeJson x) of
+      Right decoded ->
+        decoded == x
+          <?> ("x = " <> show x <> ", decoded = " <> show decoded)
+      Left err ->
+        false <?> err
+
 main = do
+  eitherCheck
   encodeDecodeCheck
   combinatorsCheck
   genericsCheck


### PR DESCRIPTION
Currently, the instances for `Either` don't record which constructor was used, which means that you get the wrong result if the two types have compatible encodings (for example, `Either String String`, or `Either Number Int`).