### PR TITLE
Add an operator for supplying a default value to getDefaultField

### DIFF
--- a/src/Data/Argonaut/Decode.purs
+++ b/src/Data/Argonaut/Decode.purs
@@ -4,4 +4,4 @@ module Data.Argonaut.Decode
   ) where
 
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
-import Data.Argonaut.Decode.Combinators (getField, (.?), getFieldOptional, (.??))
+import Data.Argonaut.Decode.Combinators (getField, (.?), getFieldOptional, (.??), defaultField, (.?=))

--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Argonaut.Core (JObject)
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.StrMap as SM
 
 getField :: forall a. DecodeJson a => JObject -> String -> Either String a
@@ -27,3 +27,8 @@ getFieldOptional o s =
     decode json = Just <$> decodeJson json
 
 infix 7 getFieldOptional as .??
+
+defaultField :: forall a. Either String (Maybe a) -> a -> Either String a
+defaultField parser default = fromMaybe default <$> parser
+
+infix 6 defaultField as .?=


### PR DESCRIPTION
This PR adds an operator for supplying a default value to `getDefaultField` (`.??`).

This is similar to Aeson's [`.!=`](https://www.stackage.org/haddock/lts-8.21/aeson-1.0.2.1/Data-Aeson.html#v:.-33--61-) operator.

The fixity needs to be less than the `.??` operator so that they compose cleanly.