### PR TITLE
include key in error message from getField functions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "purescript-foreign-object": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-quickcheck": "^5.0.0"
+    "purescript-quickcheck": "^5.0.0",
+    "purescript-test-unit": "^14.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,6 @@
     "purescript-foreign-object": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-quickcheck": "^5.0.0",
     "purescript-test-unit": "^14.0.0"
   }
 }

--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -14,6 +14,7 @@ import Data.Map as M
 import Data.Maybe (maybe, Maybe(..))
 import Data.String (CodePoint, codePointAt)
 import Data.Traversable (traverse)
+import Data.TraversableWithIndex (traverseWithIndex)
 import Data.Tuple (Tuple(..))
 import Foreign.Object as FO
 
@@ -75,8 +76,11 @@ instance decodeForeignObject :: DecodeJson a => DecodeJson (FO.Object a) where
 
 instance decodeArray :: DecodeJson a => DecodeJson (Array a) where
   decodeJson
-    = lmap ("Couldn't decode Array: " <> _)
-    <<< (traverse decodeJson <=< decodeJArray)
+    = lmap ("Couldn't decode Array (" <> _)
+    <<< (traverseWithIndex f <=< decodeJArray)
+    where
+      msg i m = "Failed at index " <> show i <> "): " <> m
+      f i = lmap (msg i) <<< decodeJson
 
 instance decodeList :: DecodeJson a => DecodeJson (List a) where
   decodeJson

--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -1,6 +1,10 @@
 module Data.Argonaut.Decode.Combinators
   ( getField
   , getFieldOptional
+  , defaultField
+  , (.?)
+  , (.??)
+  , (.?=)
   ) where
 
 import Prelude

--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -1,4 +1,7 @@
-module Data.Argonaut.Decode.Combinators where
+module Data.Argonaut.Decode.Combinators
+  ( getField
+  , getFieldOptional
+  ) where
 
 import Prelude
 

--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
+import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Foreign.Object as FO
@@ -12,7 +13,7 @@ getField :: forall a. DecodeJson a => FO.Object Json -> String -> Either String 
 getField o s =
   maybe
     (Left $ "Expected field " <> show s)
-    decodeJson
+    (elaborateFailure s <<< decodeJson)
     (FO.lookup s o)
 
 infix 7 getField as .?
@@ -24,7 +25,7 @@ getFieldOptional o s =
     decode
     (FO.lookup s o)
   where
-    decode json = Just <$> decodeJson json
+    decode json = Just <$> (elaborateFailure s <<< decodeJson) json
 
 infix 7 getFieldOptional as .??
 
@@ -32,3 +33,9 @@ defaultField :: forall a. Either String (Maybe a) -> a -> Either String a
 defaultField parser default = fromMaybe default <$> parser
 
 infix 6 defaultField as .?=
+
+elaborateFailure :: ∀ a. String -> Either String a -> Either String a
+elaborateFailure s e =
+  lmap msg e
+  where
+    msg m = "Failed to decode key '" <> s <> "': " <> m


### PR DESCRIPTION
## What does this pull request do?

Extends the error message returned in the `Left` result of `getField` and `getFieldOptional`. This will take the message coming from `decodeJson` and prepend it with a helpful message that includes the specific key that failed to decode (e.g. `Value is not a String` will become `Failed to decode 'foo': Value is not a String`).

## How should this be manually tested?

All tests are still passing, and this doesn't change the API in any way. To manually test you could create a `Json` value with a type that doesn't match what it should and see the new error on decode.

## Other Notes:

This is a very simple change that will go a long way toward making the decoding error messages more useful, however a more robust solution akin to [Aeson Better Errors](https://harry.garrood.me/blog/aeson-better-errors/) would be ideal. For now though, I think this should be good.
