### PR TITLE
Add EncodeJson/DecodeJson instances for records

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "purescript-integers": "^4.0.0",
     "purescript-maybe": "^4.0.0",
     "purescript-ordered-collections": "^1.0.0",
-    "purescript-foreign-object": "^1.0.0"
+    "purescript-foreign-object": "^1.0.0",
+    "purescript-record": "^1.0.0"
   },
   "devDependencies": {
     "purescript-test-unit": "^14.0.0"

--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -101,8 +101,12 @@ decodeJArray = maybe (Left "Value is not an Array") Right <<< toArray
 decodeJObject :: Json -> Either String (FO.Object Json)
 decodeJObject = maybe (Left "Value is not an Object") Right <<< toObject
 
+instance decodeRecord
+  :: ( GDecodeJson row list
+     , RL.RowToList row list
+     )
+  => DecodeJson (Record row) where
 
-instance decodeRecord :: (GDecodeJson row list, RL.RowToList row list) => DecodeJson (Record row) where
   decodeJson json =
     case toObject json of
       Just object -> gDecodeJson object (RLProxy :: RLProxy list)
@@ -122,13 +126,13 @@ instance gDecodeJsonCons
      , Row.Lacks field rowTail
      )
   => GDecodeJson row (RL.Cons field value tail) where
-  
+
   gDecodeJson object _ = do
     let sProxy :: SProxy field
         sProxy = SProxy
 
         fieldName = reflectSymbol sProxy
-    
+
     rest <- gDecodeJson object (RLProxy :: RLProxy tail)
 
     case FO.lookup fieldName object of

--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -1,7 +1,4 @@
-module Data.Argonaut.Decode.Class
-  ( class DecodeJson
-  , decodeJson
-  ) where
+module Data.Argonaut.Decode.Class where
 
 import Prelude
 

--- a/src/Data/Argonaut/Encode/Class.purs
+++ b/src/Data/Argonaut/Encode/Class.purs
@@ -76,9 +76,13 @@ instance encodeMap :: (Ord a, EncodeJson a, EncodeJson b) => EncodeJson (M.Map a
 instance encodeVoid :: EncodeJson Void where
   encodeJson = absurd
 
-instance encodeRecord :: (GEncodeJson row list, RL.RowToList row list) => EncodeJson (Record row) where
-  encodeJson rec = fromObject $ gEncodeJson rec (RLProxy :: RLProxy list)
+instance encodeRecord
+  :: ( GEncodeJson row list
+     , RL.RowToList row list
+     )
+  => EncodeJson (Record row) where
 
+  encodeJson rec = fromObject $ gEncodeJson rec (RLProxy :: RLProxy list)
 
 class GEncodeJson (row :: # Type) (list :: RL.RowList) where
   gEncodeJson :: Record row -> RLProxy list -> FO.Object Json
@@ -93,7 +97,7 @@ instance gEncodeJsonCons
      , Row.Cons field value tail' row
      )
   => GEncodeJson row (RL.Cons field value tail) where
-  
+
   gEncodeJson row _ =
     let
       sProxy :: SProxy field

--- a/src/Data/Argonaut/Encode/Class.purs
+++ b/src/Data/Argonaut/Encode/Class.purs
@@ -11,8 +11,13 @@ import Data.Maybe (Maybe(..))
 import Data.String (CodePoint)
 import Data.String.CodePoints as CP
 import Data.String.CodeUnits as CU
+import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Data.Tuple (Tuple(..))
 import Foreign.Object as FO
+import Prim.Row as Row
+import Prim.RowList as RL
+import Record as Record
+import Type.Data.RowList (RLProxy(..))
 
 class EncodeJson a where
   encodeJson :: a -> Json
@@ -70,3 +75,31 @@ instance encodeMap :: (Ord a, EncodeJson a, EncodeJson b) => EncodeJson (M.Map a
 
 instance encodeVoid :: EncodeJson Void where
   encodeJson = absurd
+
+instance encodeRecord :: (GEncodeJson row list, RL.RowToList row list) => EncodeJson (Record row) where
+  encodeJson rec = fromObject $ gEncodeJson rec (RLProxy :: RLProxy list)
+
+
+class GEncodeJson (row :: # Type) (list :: RL.RowList) where
+  gEncodeJson :: Record row -> RLProxy list -> FO.Object Json
+
+instance gEncodeJsonNil :: GEncodeJson row RL.Nil where
+  gEncodeJson _ _ = FO.empty
+
+instance gEncodeJsonCons
+  :: ( EncodeJson value
+     , GEncodeJson row tail
+     , IsSymbol field
+     , Row.Cons field value tail' row
+     )
+  => GEncodeJson row (RL.Cons field value tail) where
+  
+  gEncodeJson row _ =
+    let
+      sProxy :: SProxy field
+      sProxy = SProxy
+    in
+      FO.insert
+        (reflectSymbol sProxy)
+        (encodeJson $ Record.get sProxy row)
+        (gEncodeJson row $ RLProxy :: RLProxy tail)

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -17,18 +17,43 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Foreign.Object as FO
 import Test.QuickCheck (Result(..), (<?>), (===))
+import Test.QuickCheck.Arbitrary (arbitrary)
 import Test.QuickCheck.Gen (Gen, resize, suchThat)
 import Test.Unit (TestSuite, test, suite, failure)
 import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTest)
 import Test.Unit.QuickCheck (quickCheck)
 
+
 main :: Effect Unit
 main = runTest do
   suite "Either Check" eitherCheck
   suite "Encode/Decode Checks" encodeDecodeCheck
+  suite "Encode/Decode Record Checks" encodeDecodeRecordCheck
   suite "Combinators Checks" combinatorsCheck
   suite "Error Message Checks" errorMsgCheck
+
+
+genTestRecord
+  :: Gen (Record
+       ( i :: Int
+       , n :: Number
+       , s :: String
+       ))
+genTestRecord = arbitrary
+
+encodeDecodeRecordCheck :: TestSuite
+encodeDecodeRecordCheck = do
+  test "Testing that any record can be encoded and then decoded" do
+    quickCheck rec_encode_then_decode
+
+  where
+   rec_encode_then_decode :: Gen Result
+   rec_encode_then_decode = do
+    rec <- genTestRecord
+    let redecoded = decodeJson (encodeJson rec)
+    pure $ Right rec == redecoded <?> (show redecoded <> " /= Right " <> show rec)
+    
 
 genTestJson :: Gen Json
 genTestJson = resize 5 genJson


### PR DESCRIPTION
## What does this pull request do?

Addresses https://github.com/purescript-contrib/purescript-argonaut-codecs/issues/37 by allowing users to call `encodeJson` and `decodeJson` for record types. The relevant classes are implemented using `RowToList`.

## How should this be manually tested?

We've been using this branch in production at Habito for a little while and we're happy it works! I've also added some basic quickcheck tests to test the encode/decode roundtrip but I can expand on these if you'd like.

## Other Notes:

I changed `Decode.Class` to export everything, same as `Encode.Class`. If you prefer I can change `Encode.Class` to be more restrictive instead.