### PR TITLE
Add expected behavior for null values to decode functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ decodeMyTypes json = do
   x <- decodeJson json
   arr <- x .: "myTypes"
   for arr decodeJson
+
+-- create a `EncodeJson` instance
+instance encodeJsonMyType :: EncodeJson MyType where
+  encodeJson (MyType x) =
+    "foo" := x.foo ~>
+    "bar" :=? x.bar ~>? -- optional field
+    "baz" := x.baz ~>
+    jsonEmptyObject
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Using [purescript-argonaut-core](https://github.com/purescript-contrib/purescrip
 
 ```purescript
 someObject =
-  let 
-    objects = 
+  let
+    objects =
       [ jsonSingletonObject "bar" (fromString "a")
       , jsonSingletonObject "bar" (fromString "b")
       ]
@@ -33,19 +33,30 @@ someObject =
     fromObject $ Object.fromFoldable [ Tuple "foo" (fromArray objects) ]
 ```
 
-The `decodeJson` and `.?` functions provided in this module make it straightforward to interrogate the `Json` object:
+The `decodeJson` and `.:` functions provided in this module make it straightforward to interrogate the `Json` object:
 
 ```purescript
-main =
-  log $ show $ getBars someObject
+newtype MyType = MyType
+  { foo :: String
+  , bar :: Maybe Int
+  , baz :: Boolean
+  }
 
-getBars :: Json -> Either String (Array String)
-getBars json = do
-  obj <- decodeJson json
-  foo <- obj .? "foo"
-  for foo \itemJson -> do
-    itemObj <- decodeJson itemJson
-    itemObj .? "bar"
+-- create a `DecodeJson` instance
+instance decodeJsonMyType :: DecodeJson MyType where
+  decodeJson json = do
+    x <- decodeJson json
+    foo <- x .: "foo" -- mandatory field
+    bar <- x .:? "bar" -- optional field
+    baz <- x .:? "baz" .!= false -- optional field with default value of `false`
+    pure $ MyType { foo, bar, baz }
+
+-- or pass a function
+decodeMyTypes :: Json -> Either String (Array MyType)
+decodeMyTypes json = do
+  x <- decodeJson json
+  arr <- x .: "myTypes"
+  for arr decodeJson
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ someObject =
     fromObject $ Object.fromFoldable [ Tuple "foo" (fromArray objects) ]
 ```
 
-The `decodeJson` and `.:` functions provided in this module make it straightforward to interrogate the `Json` object:
+The `decodeJson`, `.:`, `.:?`, and `.!=` functions provided in this module make it straightforward to interrogate the `Json` object:
 
 ```purescript
 newtype MyType = MyType

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,12 +1129,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1149,17 +1151,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1276,7 +1281,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1288,6 +1294,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1302,6 +1309,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1309,12 +1317,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1333,6 +1343,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1413,7 +1424,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1425,6 +1437,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1546,6 +1559,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/Data/Argonaut/Decode.purs
+++ b/src/Data/Argonaut/Decode.purs
@@ -4,4 +4,4 @@ module Data.Argonaut.Decode
   ) where
 
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
-import Data.Argonaut.Decode.Combinators (parseField, (.:), parseFieldOptional, (.:!), parseFieldOptional', (.:?), defaultField, (.!=))
+import Data.Argonaut.Decode.Combinators ( getField, getFieldDeprecated, getFieldOptional, getFieldOptionalDeprecated, getFieldOptional', defaultField, defaultFieldDeprecated, (.:), (.?), (.:!), (.:?), (.??), (.!=), (.?=))

--- a/src/Data/Argonaut/Decode.purs
+++ b/src/Data/Argonaut/Decode.purs
@@ -4,4 +4,4 @@ module Data.Argonaut.Decode
   ) where
 
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
-import Data.Argonaut.Decode.Combinators (getField, (.:), getFieldOptional, (.:!), getFieldOptional', (.:?), defaultField, (.!=))
+import Data.Argonaut.Decode.Combinators (parseField, (.:), parseFieldOptional, (.:!), parseFieldOptional', (.:?), defaultField, (.!=))

--- a/src/Data/Argonaut/Decode.purs
+++ b/src/Data/Argonaut/Decode.purs
@@ -4,4 +4,4 @@ module Data.Argonaut.Decode
   ) where
 
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
-import Data.Argonaut.Decode.Combinators (getField, (.?), getFieldOptional, (.??), defaultField, (.?=))
+import Data.Argonaut.Decode.Combinators (getField, (.:), getFieldOptional, (.:!), getFieldOptional', (.:?), defaultField, (.!=))

--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -18,6 +18,10 @@ import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Foreign.Object as FO
 
+-- | Attempt to get the value for a given key on an `Object Json`.
+-- |
+-- | Use this accessor if the key and value *must* be present in your object.
+-- | If the key and value are optional, use `getFieldOptional'` (`.:?`) instead.
 getField :: forall a. DecodeJson a => FO.Object Json -> String -> Either String a
 getField o s =
   maybe
@@ -27,17 +31,13 @@ getField o s =
 
 infix 7 getField as .:
 
-getFieldOptional :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
-getFieldOptional o s =
-  maybe
-    (pure Nothing)
-    decode
-    (FO.lookup s o)
-  where
-    decode json = Just <$> (elaborateFailure s <<< decodeJson) json
-
-infix 7 getFieldOptional as .:!
-
+-- | Attempt to get the value for a given key on an `Object Json`.
+-- |
+-- | The result will be `Right Nothing` if the key and value are not present,
+-- | or if the key is present and the value is `null`.
+-- |
+-- | Use this accessor if the key and value are optional in your object.
+-- | If the key and value are mandatory, use `getField` (`.:`) instead.
 getFieldOptional' :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
 getFieldOptional' o s =
   maybe
@@ -52,6 +52,44 @@ getFieldOptional' o s =
 
 infix 7 getFieldOptional' as .:?
 
+-- | Attempt to get the value for a given key on an `Object Json`.
+-- |
+-- | The result will be `Right Nothing` if the key and value are not present,
+-- | but will fail if the key is present but the value cannot be converted to the right type.
+-- |
+-- | This function will treat `null` as a value and attempt to decode it into your desired type.
+-- | If you would like to treat `null` values the same as absent values, use
+-- | `getFieldOptional` (`.:?`) instead.
+getFieldOptional :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
+getFieldOptional o s =
+  maybe
+    (pure Nothing)
+    decode
+    (FO.lookup s o)
+  where
+    decode json = Just <$> (elaborateFailure s <<< decodeJson) json
+
+infix 7 getFieldOptional as .:!
+
+-- | Helper for use in combination with `.:?` to provide default values for optional
+-- | `Object Json` fields.
+-- |
+-- | Example usage:
+-- | ```purescript
+-- | newtype MyType = MyType
+-- |   { foo :: String
+-- |   , bar :: Maybe Int
+-- |   , baz :: Boolean
+-- |   }
+-- |
+-- | instance decodeJsonMyType :: DecodeJson MyType where
+-- |   decodeJson json = do
+-- |     x <- decodeJson json
+-- |     foo <- x .: "foo" -- mandatory field
+-- |     bar <- x .:? "bar" -- optional field
+-- |     baz <- x .:? "baz" .!= false -- optional field with default value of `false`
+-- |     pure $ MyType { foo, bar, baz }
+-- | ```
 defaultField :: forall a. Either String (Maybe a) -> a -> Either String a
 defaultField parser default = fromMaybe default <$> parser
 

--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -1,7 +1,7 @@
 module Data.Argonaut.Decode.Combinators
-  ( getField
-  , getFieldOptional
-  , getFieldOptional'
+  ( parseField
+  , parseFieldOptional
+  , parseFieldOptional'
   , defaultField
   , (.:)
   , (.:!)
@@ -21,15 +21,15 @@ import Foreign.Object as FO
 -- | Attempt to get the value for a given key on an `Object Json`.
 -- |
 -- | Use this accessor if the key and value *must* be present in your object.
--- | If the key and value are optional, use `getFieldOptional'` (`.:?`) instead.
-getField :: forall a. DecodeJson a => FO.Object Json -> String -> Either String a
-getField o s =
+-- | If the key and value are optional, use `parseFieldOptional'` (`.:?`) instead.
+parseField :: forall a. DecodeJson a => FO.Object Json -> String -> Either String a
+parseField o s =
   maybe
     (Left $ "Expected field " <> show s)
     (elaborateFailure s <<< decodeJson)
     (FO.lookup s o)
 
-infix 7 getField as .:
+infix 7 parseField as .:
 
 -- | Attempt to get the value for a given key on an `Object Json`.
 -- |
@@ -37,9 +37,9 @@ infix 7 getField as .:
 -- | or if the key is present and the value is `null`.
 -- |
 -- | Use this accessor if the key and value are optional in your object.
--- | If the key and value are mandatory, use `getField` (`.:`) instead.
-getFieldOptional' :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
-getFieldOptional' o s =
+-- | If the key and value are mandatory, use `parseField` (`.:`) instead.
+parseFieldOptional' :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
+parseFieldOptional' o s =
   maybe
     (pure Nothing)
     decode
@@ -50,7 +50,7 @@ getFieldOptional' o s =
         then pure Nothing
         else Just <$> decodeJson json
 
-infix 7 getFieldOptional' as .:?
+infix 7 parseFieldOptional' as .:?
 
 -- | Attempt to get the value for a given key on an `Object Json`.
 -- |
@@ -59,9 +59,9 @@ infix 7 getFieldOptional' as .:?
 -- |
 -- | This function will treat `null` as a value and attempt to decode it into your desired type.
 -- | If you would like to treat `null` values the same as absent values, use
--- | `getFieldOptional` (`.:?`) instead.
-getFieldOptional :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
-getFieldOptional o s =
+-- | `parseFieldOptional` (`.:?`) instead.
+parseFieldOptional :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
+parseFieldOptional o s =
   maybe
     (pure Nothing)
     decode
@@ -69,7 +69,7 @@ getFieldOptional o s =
   where
     decode json = Just <$> (elaborateFailure s <<< decodeJson) json
 
-infix 7 getFieldOptional as .:!
+infix 7 parseFieldOptional as .:!
 
 -- | Helper for use in combination with `.:?` to provide default values for optional
 -- | `Object Json` fields.


### PR DESCRIPTION
## What does this pull request do?

Renames decode combinators and introduces a new one that treats `null` values as missing values. See discussion here: #32

The reason for this boils down to the current combinators not behaving as most users would expect, but updating their behavior would break existing codebases without them knowing. So the solution was to rename the functions altogether, now matching their analogues in Haskell's Aeson library.

Also added some tests. I couldn't figure out how to test the decode combinators with QuickCheck. Even for the existing tests, the one that claimed to be testing `.?` (now `.:`) wasn't. So instead I added a suite of manual tests.

## Where should the reviewer start?

`src/Data/Argonaut/Decode/Combinators.purs` contains the meat of the updates. Then the tests also illustrate the intended behavior. 

## How should this be manually tested?

Beyond running the tests, if you have any projects that use this library you could test those.

## Other Notes:

This is a breaking change and will require a major version bump.