### PR TITLE
Add instances for Data.Set

### DIFF
--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -12,6 +12,7 @@ import Data.List as L
 import Data.Map as M
 import Data.Maybe (maybe, Maybe(..))
 import Data.NonEmpty (NonEmpty, (:|))
+import Data.Set as S
 import Data.String (CodePoint, codePointAt)
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Data.Traversable (traverse)
@@ -101,6 +102,9 @@ instance decodeList :: DecodeJson a => DecodeJson (List a) where
   decodeJson
     = lmap ("Couldn't decode List: " <> _)
     <<< (traverse decodeJson <=< map (map fromFoldable) decodeJArray)
+
+instance decodeSet :: (Ord a, DecodeJson a) => DecodeJson (S.Set a) where
+  decodeJson = map (S.fromFoldable :: List a -> S.Set a) <<< decodeJson
 
 instance decodeMap :: (Ord a, DecodeJson a, DecodeJson b) => DecodeJson (M.Map a b) where
   decodeJson = map (M.fromFoldable :: List (Tuple a b) -> M.Map a b) <<< decodeJson

--- a/src/Data/Argonaut/Encode/Class.purs
+++ b/src/Data/Argonaut/Encode/Class.purs
@@ -11,6 +11,7 @@ import Data.List as L
 import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.NonEmpty (NonEmpty(..))
+import Data.Set as S
 import Data.String (CodePoint)
 import Data.String.CodePoints as CP
 import Data.String.CodeUnits as CU
@@ -78,6 +79,9 @@ instance encodeJsonList :: EncodeJson a => EncodeJson (List a) where
 
 instance encodeForeignObject :: EncodeJson a => EncodeJson (FO.Object a) where
   encodeJson = fromObject <<< map encodeJson
+
+instance encodeSet :: (Ord a, EncodeJson a) => EncodeJson (S.Set a) where
+  encodeJson = encodeJson <<< (S.toUnfoldable :: S.Set a -> List a)
 
 instance encodeMap :: (Ord a, EncodeJson a, EncodeJson b) => EncodeJson (M.Map a b) where
   encodeJson = encodeJson <<< (M.toUnfoldable :: M.Map a b -> List (Tuple a b))


### PR DESCRIPTION
Adds `EncodeJson` and `DecodeJson` instances for Data.Set.Set. Since we already have the `ordered-collections` dependency, this seems like an easy win.

Let me know what you think. Thank you!
-be