### PR TITLE
correct a typo in getFieldOptional docs

### DIFF
--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -76,7 +76,7 @@ infix 7 getFieldOptional' as .:?
 -- |
 -- | This function will treat `null` as a value and attempt to decode it into your desired type.
 -- | If you would like to treat `null` values the same as absent values, use
--- | `getFieldOptional` (`.:?`) instead.
+-- | `getFieldOptional'` (`.:?`) instead.
 getFieldOptional :: forall a. DecodeJson a => FO.Object Json -> String -> Either String (Maybe a)
 getFieldOptional o s =
   maybe


### PR DESCRIPTION
## What does this pull request do?
I was trying to write some JSON decoders and came accross this typo that confused me momentarily. The description for `getFieldOptional` suggests using itself for slightly different behaviour, when I believe that it should be referring to `getFieldOptional'`
