### PR TITLE
Add encode/decode instances for `Identity a`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,8 @@
     "purescript-foreign-object": "^2.0.0",
     "purescript-record": "^2.0.0",
     "purescript-nonempty": "^5.0.0",
-    "purescript-arrays": "^5.1.0"
+    "purescript-arrays": "^5.1.0",
+    "purescript-identity": "^4.1.0"
   },
   "devDependencies": {
     "purescript-assert": "^4.1.0",

--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -6,6 +6,7 @@ import Data.Argonaut.Core (Json, isNull, caseJsonNull, caseJsonBoolean, caseJson
 import Data.Array as Arr
 import Data.Bifunctor (lmap, rmap)
 import Data.Either (Either(..), note)
+import Data.Identity (Identity(..))
 import Data.Int (fromNumber)
 import Data.List (List(..), (:), fromFoldable)
 import Data.List as L
@@ -26,6 +27,9 @@ import Type.Data.RowList (RLProxy(..))
 
 class DecodeJson a where
   decodeJson :: Json -> Either String a
+
+instance decodeIdentity :: DecodeJson a => DecodeJson (Identity a) where
+  decodeJson j = Identity <$> decodeJson j
 
 instance decodeJsonMaybe :: DecodeJson a => DecodeJson (Maybe a) where
   decodeJson j

--- a/src/Data/Argonaut/Encode/Class.purs
+++ b/src/Data/Argonaut/Encode/Class.purs
@@ -5,6 +5,7 @@ import Prelude
 import Data.Argonaut.Core (Json, fromArray, fromBoolean, fromNumber, fromObject, fromString, jsonNull)
 import Data.Array as Arr
 import Data.Either (Either, either)
+import Data.Identity (Identity(..))
 import Data.Int (toNumber)
 import Data.List (List(..), (:), toUnfoldable)
 import Data.List as L
@@ -25,6 +26,9 @@ import Type.Data.RowList (RLProxy(..))
 
 class EncodeJson a where
   encodeJson :: a -> Json
+
+instance encodeIdentity :: EncodeJson a => EncodeJson (Identity a) where
+  encodeJson (Identity a) = encodeJson a
 
 instance encodeJsonMaybe :: EncodeJson a => EncodeJson (Maybe a) where
   encodeJson Nothing  = jsonNull


### PR DESCRIPTION
## What does this pull request do?

Adds trivial encode/decode instances for `Identity a`. I ran into this when trying to encode a data type that looks like this -

```purescript
data Entity f = Entity
  { guid :: f Guid
  , <some other fields here>
  }
```

When the entity has a Guid it can be persisted as `Entity Identity`. This is a very common pattern.

However in the absence of an encode instance for `Identity a`, I have to manually encode `Entity` while unwrapping the guid field, which is a bit ugly.
