### PR TITLE
Fix typo in comment at top of Encode.purs

### DIFF
--- a/src/Data/Argonaut/Encode/Combinators.purs
+++ b/src/Data/Argonaut/Encode/Combinators.purs
@@ -4,8 +4,8 @@
 -- | myJson
 -- |  = "key1" := value1
 -- |  ~> "key2" :=? value2
--- | ~>? "key3" := value3
--- |  ~> jsonEmptyOibject
+-- |  ~>? "key3" := value3
+-- |  ~> jsonEmptyObject
 -- | ```
 module Data.Argonaut.Encode.Combinators where
 


### PR DESCRIPTION
A simple fix of a typo in the comments. Should have no impact whatsoever on functionality.