### PR TITLE
Fix associativity of inline type annotation

### DIFF
--- a/src/Data/Argonaut/Encode/Class.purs
+++ b/src/Data/Argonaut/Encode/Class.purs
@@ -119,4 +119,4 @@ instance gEncodeJsonCons
       FO.insert
         (reflectSymbol sProxy)
         (encodeJson $ Record.get sProxy row)
-        (gEncodeJson row $ RLProxy :: RLProxy tail)
+        (gEncodeJson row (RLProxy :: RLProxy tail))


### PR DESCRIPTION
This does not parse in `purs` master.