### PR TITLE
Deprecate .:? and add notes to .:! and .!= about use

### DIFF
--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -2,10 +2,11 @@ module Test.Main where
 
 import Prelude
 
+import Control.Alternative ((<|>))
 import Control.Monad.Gen.Common (genMaybe)
 import Control.Monad.Reader (ReaderT, ask, local, runReaderT)
 import Data.Argonaut.Core (Json, isObject, stringify, toObject)
-import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.:), (.:!), (.:?), (.!=))
+import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.:), (.:!), (.!=))
 import Data.Argonaut.Encode (encodeJson, (:=), (:=?), (~>), (~>?))
 import Data.Argonaut.Gen (genJson)
 import Data.Argonaut.Parser (jsonParser)
@@ -371,8 +372,8 @@ newtype FooNested = FooNested
 instance decodeJsonFooNested :: DecodeJson FooNested where
   decodeJson json = do
     x <- decodeJson json
-    bar <- x .:! "bar"
-    baz <- x .:! "baz" .!= false
+    bar <- x .: "bar"
+    baz <- x .: "baz" <|> pure false
     pure $ FooNested { bar, baz }
 
 newtype FooNested' = FooNested'
@@ -383,6 +384,6 @@ newtype FooNested' = FooNested'
 instance decodeJsonFooNested' :: DecodeJson FooNested' where
   decodeJson json = do
     x <- decodeJson json
-    bar <- x .:? "bar"
-    baz <- x .:? "baz" .!= false
+    bar <- x .:! "bar"
+    baz <- x .:! "baz" .!= false
     pure $ FooNested' { bar, baz }


### PR DESCRIPTION
## What does this pull request do?

Closes #63 by deprecating the `.:?` operator and updating documentation to steer folks away from `.:!` and `.!=` except in the (seemingly quite rare) case in which their behavior is desired rather than the behavior of `.:` for its `Maybe` instance.

#63 describes why `.:?` is unnecessary, and #47 and #32 describe why it was introduced in the first place and why `.:!` should not be promoted as the most common way to decode an optional field.

#63 also describes why `.!=` is unnecessary when using `.:` to get fields; I would like to have deprecated it in this pull request, but it is still useful when using `.:!`, so I've kept it in. 

I did add a note about it only being required with `.:!` and not with `.:`, where the better `<|> pure default` can be used instead. I would like to promote using `<|>` instead because it's a natural step from there to realize you can supply multiple ways to parse a field and only take the first successful decoded value.

## Where should the reviewer start?

All code changes are in `Decode`, and the tests have updated to use the new operators.

## Other Notes:

The project tutorial should be updated to introduce `<|> pure default` earlier, rather than introducing `.!=` first.