### PR TITLE
Correct Newtype instance deriving example

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ In that case, we can use newtype deriving to get `EncodeJson` and `DecodeJson` f
 ```purs
 newtype AppUser = AppUser { name :: String, age :: Maybe Int, team :: Team }
 
-instance newtypeAppUser :: Newtype AppUser _
+derive instance newtypeAppUser :: Newtype AppUser _
 
 derive newtype instance encodeJsonAppUser :: EncodeJson AppUser
 derive newtype instance decodeJsonAppUser :: DecodeJson AppUser


### PR DESCRIPTION
## What does this pull request do?

Corrects the Newtype deriving example with missing `derive` keyword
