### PR TITLE
Decode Tuple as Array instead of List internally

### DIFF
--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -10,7 +10,7 @@ import Data.Bifunctor (lmap, rmap)
 import Data.Either (Either(..), note)
 import Data.Identity (Identity(..))
 import Data.Int (fromNumber)
-import Data.List (List(..), (:), fromFoldable)
+import Data.List (List, fromFoldable)
 import Data.List as L
 import Data.List.NonEmpty (NonEmptyList)
 import Data.List.NonEmpty as NEL
@@ -43,7 +43,7 @@ instance decodeJsonMaybe :: DecodeJson a => DecodeJson (Maybe a) where
 instance decodeJsonTuple :: (DecodeJson a, DecodeJson b) => DecodeJson (Tuple a b) where
   decodeJson j = decodeJson j >>= f
     where
-    f (a : b : Nil) = Tuple <$> decodeJson a <*> decodeJson b
+    f [a, b] = Tuple <$> decodeJson a <*> decodeJson b
     f _ = Left "Couldn't decode Tuple"
 
 instance decodeJsonEither :: (DecodeJson a, DecodeJson b) => DecodeJson (Either a b) where


### PR DESCRIPTION
## What does this pull request do?

This PR makes `decodeJsonTuple` more closely match `encodeJsonTuple` (which encodes internally to `Array`).

Background discussion here:
https://functionalprogramming.slack.com/archives/C04NA444H/p1589306847445300

## How should this be manually tested?

Tuple encoding/decoding is already covered by existing quickCheck testing.