### PR TITLE
 Beginner-friendly syntax in decodeJsonTuple

### DIFF
--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -10,7 +10,7 @@ import Data.Bifunctor (lmap, rmap)
 import Data.Either (Either(..), note)
 import Data.Identity (Identity(..))
 import Data.Int (fromNumber)
-import Data.List (List(..), (:), fromFoldable)
+import Data.List (List, fromFoldable)
 import Data.List as L
 import Data.List.NonEmpty (NonEmptyList)
 import Data.List.NonEmpty as NEL
@@ -43,7 +43,7 @@ instance decodeJsonMaybe :: DecodeJson a => DecodeJson (Maybe a) where
 instance decodeJsonTuple :: (DecodeJson a, DecodeJson b) => DecodeJson (Tuple a b) where
   decodeJson j = decodeJson j >>= f
     where
-    f (a : b : Nil) = Tuple <$> decodeJson a <*> decodeJson b
+    f [a, b] = Tuple <$> decodeJson a <*> decodeJson b
     f _ = Left "Couldn't decode Tuple"
 
 instance decodeJsonEither :: (DecodeJson a, DecodeJson b) => DecodeJson (Either a b) where


### PR DESCRIPTION
This is just different syntax that's functionally equivalent. It is covered by, and passes, existing quickCheck tests.

Motivation for this change is that I'm planning on pointing readers of [Ch10](https://book.purescript.org/chapter10.html) (rewrite targeting argonaut in-progress) to `decodeJsonTuple` for guidance on writing their own `DecodeJson` instances in one of the exercises, and I'd like this library example to be as easy as possible for beginners to grok.

This is an extension of #75.