### PR TITLE
Miror clarifications to multi-arg example

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,12 +429,10 @@ encodeUserAsArray user = encodeJson [ user.uuid, user.name ]
 You may occasionally be unable to write `EncodeJson` or `DecodeJson` instances for a data type because it requires more information than just `Json` as its argument. For instance, consider this pair of types:
 
 ```purs
-newtype Following
-  = Following Boolean
-
 data Author
-  = Other String Following -- someone else is the author
-  | You                    -- you are the author
+  = Following String    -- you are subscribed to this author
+  | NotFollowing String -- you aren't subscribed to this author
+  | You                 -- you are the author
 
 type BlogPost =
   { title :: String
@@ -456,10 +454,9 @@ decodeJsonAuthor maybeUsername json = do
   following <- obj .: "following"
   case maybeUsername of
     -- user is logged in and is the author
-    Just (Username username)
-      | author == username -> Right You
+    Just (Username username) | author == username -> Right You
     -- user is not the author, or no one is logged in, so use the `following` flag
-    _ -> Right $ Other author $ Following following
+    _ -> if following then Following else NotFollowing $ author
 
 decodeJsonBlogPost :: Maybe Username -> Json -> Either JsonDecodeError BlogPost
 decodeJsonBlogPost username json = do

--- a/README.md
+++ b/README.md
@@ -429,9 +429,12 @@ encodeUserAsArray user = encodeJson [ user.uuid, user.name ]
 You may occasionally be unable to write `EncodeJson` or `DecodeJson` instances for a data type because it requires more information than just `Json` as its argument. For instance, consider this pair of types:
 
 ```purs
+newtype Following
+  = Following Boolean
+
 data Author
-  = Other String Boolean -- someone else is the author
-  | You                  -- you are the author
+  = Other String Following -- someone else is the author
+  | You                    -- you are the author
 
 type BlogPost =
   { title :: String
@@ -455,9 +458,8 @@ decodeJsonAuthor maybeUsername json = do
     -- user is logged in and is the author
     Just (Username username)
       | author == username -> Right You
-      -- user is not the author, or no one is logged in, so use the `following` flag
-      | otherwise -> Right $ Other author following
-    Nothing -> Left $ Named "Username" MissingValue
+    -- user is not the author, or no one is logged in, so use the `following` flag
+    _ -> Right $ Other author $ Following following
 
 decodeJsonBlogPost :: Maybe Username -> Json -> Either JsonDecodeError BlogPost
 decodeJsonBlogPost username json = do

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ type BlogPost =
   }
 ```
 
-Our API tells us the author of the blog post is a `String` and whether we follow them is a `Boolean`. This admits more cases than are actually possible -- you can't follow yourself, for example -- so we are more precise and model an `Author` as a sum type.
+Our API sends us the author of the blog post as a string and whether we follow them as a boolean. This admits more cases than are actually possible -- you can't follow yourself, for example -- so we are more precise and model an `Author` as a sum type.
 
 When our application is running we know who the currently-authenticated user is, and we can use that information to determine the `Author` type. That means we can't decode an `Author` from `Json` alone -- we need more information.
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ When our application is running we know who the currently-authenticated user is,
 In these cases, unfortunately, you can't write an instance of `DecodeJson` for the data type. You can, however, write `decodeJsonAuthor` and use it without the type class. For instance:
 
 ```purs
-decodeJsonAuthor :: Maybe Username -> Json -> Either String Author
+decodeJsonAuthor :: Maybe Username -> Json -> Either JsonDecodeError Author
 decodeJsonAuthor maybeUsername json = do
   obj <- decodeJson json
   author <- obj .: "author"
@@ -457,9 +457,9 @@ decodeJsonAuthor maybeUsername json = do
       | author == username -> Right You
       -- user is not the author, or no one is logged in, so use the `following` flag
       | otherwise -> Right $ Other author following
-    Nothing -> Left "Missing Username"
+    Nothing -> Left $ Named "Username" MissingValue
 
-decodeJsonBlogPost :: Maybe Username -> Json -> Either String BlogPost
+decodeJsonBlogPost :: Maybe Username -> Json -> Either JsonDecodeError BlogPost
 decodeJsonBlogPost username json = do
   obj <- decodeJson json
   title <- obj .: "title"

--- a/README.md
+++ b/README.md
@@ -452,11 +452,11 @@ decodeJsonAuthor maybeUsername json = do
   obj <- decodeJson json
   author <- obj .: "author"
   following <- obj .: "following"
-  case maybeUsername of
+  pure $ case maybeUsername of
     -- user is logged in and is the author
-    Just (Username username) | author == username -> Right You
+    Just (Username username) | author == username -> You
     -- user is not the author, or no one is logged in, so use the `following` flag
-    _ -> if following then Following else NotFollowing $ author
+    _ -> author # if following then Following else NotFollowing
 
 decodeJsonBlogPost :: Maybe Username -> Json -> Either JsonDecodeError BlogPost
 decodeJsonBlogPost username json = do


### PR DESCRIPTION
## What does this pull request do?

Fixes broken example so it compiles.
Also adds some simplifications without detracting from what this section teaches.

## Other Notes:

There are lots of other required fixes in these docs to change `JsonDecodeError` to `String`, but that should probably be another PR.

A bonus goal is to ensure inline snippets always compile by linking them to source files that are compiled as part of CI.