### PR TITLE
Add encoder for NonEmptyString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes (😱!!!):
 
 New features:
 - Added decoders for `NonEmptyString` and added a new `decodeNonempty` function (#94)
+- Added encoder for `NonEmptyString` (d0liver, #98)
 
 Bugfixes:
 

--- a/src/Data/Argonaut/Encode/Class.purs
+++ b/src/Data/Argonaut/Encode/Class.purs
@@ -4,6 +4,7 @@ import Data.Argonaut.Encode.Encoders
 
 import Data.Argonaut.Core (Json, fromObject)
 import Data.Array.NonEmpty (NonEmptyArray)
+import Data.String.NonEmpty (NonEmptyString)
 import Data.Either (Either)
 import Data.Identity (Identity)
 import Data.List (List)
@@ -57,6 +58,9 @@ instance encodeJsonJson :: EncodeJson Json where
 
 instance encodeJsonCodePoint :: EncodeJson CodePoint where
   encodeJson = encodeCodePoint
+
+instance encodeNonEmptyString :: EncodeJson NonEmptyString where
+  encodeJson = encodeNonEmptyString
 
 instance encodeJsonNonEmpty_Array :: (EncodeJson a) => EncodeJson (NonEmpty Array a) where
   encodeJson = encodeNonEmpty_Array encodeJson

--- a/src/Data/Argonaut/Encode/Encoders.purs
+++ b/src/Data/Argonaut/Encode/Encoders.purs
@@ -12,6 +12,8 @@ import Data.Int (toNumber)
 import Data.List (List(..), (:), toUnfoldable)
 import Data.List.NonEmpty as NEL
 import Data.List.Types (NonEmptyList)
+import Data.String.NonEmpty (NonEmptyString)
+import Data.String.NonEmpty as NonEmptyString
 import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.NonEmpty (NonEmpty(..))
@@ -59,6 +61,9 @@ encodeString = fromString
 
 encodeCodePoint :: CodePoint -> Json
 encodeCodePoint = encodeString <<< CP.singleton
+
+encodeNonEmptyString :: NonEmptyString -> Json
+encodeNonEmptyString = fromString <<< NonEmptyString.toString
 
 encodeNonEmpty_Array :: forall a. (a -> Json) -> NonEmpty Array a -> Json
 encodeNonEmpty_Array encoder (NonEmpty h t) = encodeArray encoder (Arr.cons h t)

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -11,6 +11,8 @@ import Data.Argonaut.Encode (encodeJson, (:=), (:=?), (~>), (~>?))
 import Data.Argonaut.Gen (genJson)
 import Data.Argonaut.Parser (jsonParser)
 import Data.Array.NonEmpty (NonEmptyArray)
+import Data.String.NonEmpty (NonEmptyString)
+import Data.String.NonEmpty as NonEmptyString
 import Data.Bifunctor (rmap)
 import Data.Either (Either(..), either)
 import Data.Foldable (foldl)
@@ -311,6 +313,21 @@ nonEmptyCheck = do
         Right decoded ->
           decoded == x
             <?> ("x = " <> show x <> ", decoded = " <> show decoded)
+        Left err ->
+          false <?> printJsonDecodeError err
+
+
+  test "Test EncodeJson/DecodeJson on NonEmptyString" do
+    quickCheck \(x :: NonEmptyString) ->
+      case decodeJson (encodeJson x) of
+        Right decoded ->
+          decoded == x
+            <?>
+              (  " x = "
+              <> NonEmptyString.toString x
+              <> ", decoded = "
+              <> NonEmptyString.toString decoded
+              )
         Left err ->
           false <?> printJsonDecodeError err
 


### PR DESCRIPTION
Added an `EncodeJson` instance for `NonEmptyString`s and a test for the `EncodeJson` and `DecodeJson` instances for `NonEmptyString`s.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
