### PR TITLE
fix warnings and missing direct dependencies causing CI failures

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,19 +16,28 @@
   "dependencies": {
     "purescript-argonaut-core": "^6.0.0",
     "purescript-arrays": "^6.0.0",
+    "purescript-bifunctors": "^5.0.0",
     "purescript-effect": "^3.0.0",
+    "purescript-either": "^5.0.0",
+    "purescript-foldable-traversable": "^5.0.0",
     "purescript-foreign-object": "^3.0.0",
     "purescript-identity": "^5.0.0",
     "purescript-integers": "^5.0.0",
+    "purescript-lists": "^6.0.0",
     "purescript-maybe": "^5.0.0",
     "purescript-nonempty": "^6.0.0",
     "purescript-ordered-collections": "^2.0.0",
     "purescript-prelude": "^5.0.0",
-    "purescript-record": "^3.0.0"
+    "purescript-record": "^3.0.0",
+    "purescript-strings": "^5.0.0",
+    "purescript-tuples": "^6.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^5.0.0",
     "purescript-console": "^5.0.0",
-    "purescript-quickcheck": "^7.0.0"
+    "purescript-exceptions": "^5.0.0",
+    "purescript-gen": "^3.0.0",
+    "purescript-quickcheck": "^7.0.0",
+    "purescript-transformers": "^5.0.0"
   }
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -6,11 +6,17 @@
   [ "argonaut-core"
   , "arrays"
   , "assert"
+  , "bifunctors"
   , "console"
   , "effect"
+  , "either"
+  , "exceptions"
+  , "foldable-traversable"
   , "foreign-object"
+  , "gen"
   , "identity"
   , "integers"
+  , "lists"
   , "maybe"
   , "nonempty"
   , "ordered-collections"
@@ -18,6 +24,9 @@
   , "psci-support"
   , "quickcheck"
   , "record"
+  , "strings"
+  , "transformers"
+  , "tuples"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -185,7 +185,7 @@ combinatorsCheck = do
     obj <- genObj
     let appended = (key := val) ~> obj
     case toObject appended >>= FO.lookup key of
-      Just value -> pure Success
+      Just _ -> pure Success
       _ -> pure (Failed "failed to lookup key")
 
   propAssocAppendOptional :: Gen Result
@@ -195,7 +195,7 @@ combinatorsCheck = do
     obj <- genObj
     let appended = (key :=? maybeVal) ~>? obj
     pure case toObject appended >>= FO.lookup key of
-      Just value -> isJust maybeVal === true
+      Just _ -> isJust maybeVal === true
       _ -> isNothing maybeVal === true
 
   propGetJObjectField :: Gen Result


### PR DESCRIPTION
**Description of the change**
Fixes some code warnings and missing direct dependencies that cause the CI to fail.  See ([purescript-contrib/governance#43](https://github.com/purescript-contrib/governance/issues/43)).
---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
