### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#104 by @thomashoneyman)
 
 ## [v8.1.0](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v8.1.0) - 2021-04-09
 

--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -94,11 +94,11 @@ instance decodeMap :: (Ord a, DecodeJson a, DecodeJson b) => DecodeJson (M.Map a
 instance decodeVoid :: DecodeJson Void where
   decodeJson = decodeVoid
 
-instance decodeRecord
-  :: ( GDecodeJson row list
-     , RL.RowToList row list
-     )
-  => DecodeJson (Record row) where
+instance decodeRecord ::
+  ( GDecodeJson row list
+  , RL.RowToList row list
+  ) =>
+  DecodeJson (Record row) where
   decodeJson json =
     case toObject json of
       Just object -> gDecodeJson object (Proxy :: Proxy list)
@@ -110,14 +110,14 @@ class GDecodeJson (row :: Row Type) (list :: RL.RowList Type) | list -> row wher
 instance gDecodeJsonNil :: GDecodeJson () RL.Nil where
   gDecodeJson _ _ = Right {}
 
-instance gDecodeJsonCons
-  :: ( DecodeJsonField value
-     , GDecodeJson rowTail tail
-     , IsSymbol field
-     , Row.Cons field value rowTail row
-     , Row.Lacks field rowTail
-     )
-  => GDecodeJson row (RL.Cons field value tail) where
+instance gDecodeJsonCons ::
+  ( DecodeJsonField value
+  , GDecodeJson rowTail tail
+  , IsSymbol field
+  , Row.Cons field value rowTail row
+  , Row.Lacks field rowTail
+  ) =>
+  GDecodeJson row (RL.Cons field value tail) where
   gDecodeJson object _ = do
     let
       _field = Proxy :: Proxy field
@@ -136,13 +136,13 @@ instance gDecodeJsonCons
 class DecodeJsonField a where
   decodeJsonField :: Maybe Json -> Maybe (Either JsonDecodeError a)
 
-instance decodeFieldMaybe
-  :: DecodeJson a
-  => DecodeJsonField (Maybe a) where
+instance decodeFieldMaybe ::
+  DecodeJson a =>
+  DecodeJsonField (Maybe a) where
   decodeJsonField Nothing = Just $ Right Nothing
   decodeJsonField (Just j) = Just $ decodeJson j
 
-else instance decodeFieldId
-  :: DecodeJson a
-  => DecodeJsonField a where
+else instance decodeFieldId ::
+  DecodeJson a =>
+  DecodeJsonField a where
   decodeJsonField j = decodeJson <$> j

--- a/src/Data/Argonaut/Decode/Decoders.purs
+++ b/src/Data/Argonaut/Decode/Decoders.purs
@@ -53,7 +53,7 @@ decodeTuple decoderA decoderB json = decodeArray Right json >>= f
   where
   f :: Array Json -> Either JsonDecodeError (Tuple a b)
   f = case _ of
-    [a, b] -> Tuple <$> decoderA a <*> decoderB b
+    [ a, b ] -> Tuple <$> decoderA a <*> decoderB b
     _ -> Left $ TypeMismatch "Tuple"
 
 decodeEither
@@ -100,8 +100,8 @@ decodeNonEmpty_Array decoder =
   lmap (Named "NonEmpty Array")
     <<< traverse decoder
     <=< map (\x -> x.head :| x.tail)
-    <<< note (TypeMismatch "NonEmpty Array")
-    <<< Arr.uncons
+      <<< note (TypeMismatch "NonEmpty Array")
+      <<< Arr.uncons
     <=< decodeJArray
 
 decodeNonEmptyArray
@@ -113,8 +113,8 @@ decodeNonEmptyArray decoder =
   lmap (Named "NonEmptyArray")
     <<< traverse decoder
     <=< map (\x -> NEA.cons' x.head x.tail)
-    <<< note (TypeMismatch "NonEmptyArray")
-    <<< Arr.uncons
+      <<< note (TypeMismatch "NonEmptyArray")
+      <<< Arr.uncons
     <=< decodeJArray
 
 decodeNonEmpty_List
@@ -126,8 +126,8 @@ decodeNonEmpty_List decoder =
   lmap (Named "NonEmpty List")
     <<< traverse decoder
     <=< map (\x -> x.head :| x.tail)
-    <<< note (TypeMismatch "NonEmpty List")
-    <<< L.uncons
+      <<< note (TypeMismatch "NonEmpty List")
+      <<< L.uncons
     <=< map (map fromFoldable) decodeJArray
 
 decodeNonEmptyList
@@ -139,8 +139,8 @@ decodeNonEmptyList decoder =
   lmap (Named "NonEmptyList")
     <<< traverse decoder
     <=< map (\x -> NEL.cons' x.head x.tail)
-    <<< note (TypeMismatch "NonEmptyList")
-    <<< L.uncons
+      <<< note (TypeMismatch "NonEmptyList")
+      <<< L.uncons
     <=< map (map fromFoldable) decodeJArray
 
 decodeCodePoint :: Json -> Either JsonDecodeError CodePoint

--- a/src/Data/Argonaut/Encode/Class.purs
+++ b/src/Data/Argonaut/Encode/Class.purs
@@ -95,11 +95,11 @@ instance encodeMap :: (Ord a, EncodeJson a, EncodeJson b) => EncodeJson (M.Map a
 instance encodeVoid :: EncodeJson Void where
   encodeJson = encodeVoid
 
-instance encodeRecord
-  :: ( GEncodeJson row list
-     , RL.RowToList row list
-     )
-  => EncodeJson (Record row) where
+instance encodeRecord ::
+  ( GEncodeJson row list
+  , RL.RowToList row list
+  ) =>
+  EncodeJson (Record row) where
   encodeJson rec = fromObject $ gEncodeJson rec (Proxy :: Proxy list)
 
 class GEncodeJson (row :: Row Type) (list :: RL.RowList Type) where
@@ -108,13 +108,13 @@ class GEncodeJson (row :: Row Type) (list :: RL.RowList Type) where
 instance gEncodeJsonNil :: GEncodeJson row RL.Nil where
   gEncodeJson _ _ = FO.empty
 
-instance gEncodeJsonCons
-  :: ( EncodeJson value
-     , GEncodeJson row tail
-     , IsSymbol field
-     , Row.Cons field value tail' row
-     )
-  => GEncodeJson row (RL.Cons field value tail) where
+instance gEncodeJsonCons ::
+  ( EncodeJson value
+  , GEncodeJson row tail
+  , IsSymbol field
+  , Row.Cons field value tail' row
+  ) =>
+  GEncodeJson row (RL.Cons field value tail) where
   gEncodeJson row _ = do
     let _field = Proxy :: Proxy field
     FO.insert

--- a/src/Data/Argonaut/Encode/Encoders.purs
+++ b/src/Data/Argonaut/Encode/Encoders.purs
@@ -33,9 +33,9 @@ encodeMaybe encoder = case _ of
   Just a -> encoder a
 
 encodeTuple :: forall a b. (a -> Json) -> (b -> Json) -> Tuple a b -> Json
-encodeTuple encoderA encoderB (Tuple a b) = fromArray [encoderA a, encoderB b]
+encodeTuple encoderA encoderB (Tuple a b) = fromArray [ encoderA a, encoderB b ]
 
-encodeEither :: forall a b . (a -> Json) -> (b -> Json) -> Either a b -> Json
+encodeEither :: forall a b. (a -> Json) -> (b -> Json) -> Either a b -> Json
 encodeEither encoderA encoderB = either (obj encoderA "Left") (obj encoderB "Right")
   where
   obj :: forall c. (c -> Json) -> String -> c -> Json

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -206,8 +206,10 @@ combinatorsCheck = do
     where
     go :: FO.Object Json -> Boolean
     go object =
-      let keys = FO.keys object
-      in foldl (\ok key -> ok && isJust (FO.lookup key object)) true keys
+      let
+        keys = FO.keys object
+      in
+        foldl (\ok key -> ok && isJust (FO.lookup key object)) true keys
 
 eitherCheck :: Test
 eitherCheck = do
@@ -287,7 +289,7 @@ manualRecordDecode = do
     testBazCases = do
       test "Missing 'baz' key should decode to FooNested" do
         case decodeJson fooNestedBarJson of
-          Right (FooNested { bar: Just [1], baz: false }) -> pure unit
+          Right (FooNested { bar: Just [ 1 ], baz: false }) -> pure unit
           _ -> failure ("Failed to properly decode JSON string: " <> stringify fooNestedBarJson)
 
       test "Null 'baz' key should fail to decode to FooNested" do
@@ -297,24 +299,24 @@ manualRecordDecode = do
 
       test "Missing 'baz' key should decode to FooNested'" do
         case decodeJson fooNestedBarJson of
-          Right (FooNested' { bar: Just [1], baz: false }) -> pure unit
+          Right (FooNested' { bar: Just [ 1 ], baz: false }) -> pure unit
           _ -> failure ("Failed to properly decode JSON string: " <> stringify fooNestedBarJson)
 
       test "Null 'baz' key should decode to FooNested'" do
         case decodeJson fooNestedBarJsonNull of
-          Right (FooNested' { bar: Just [1], baz: false }) -> pure unit
+          Right (FooNested' { bar: Just [ 1 ], baz: false }) -> pure unit
           _ -> failure ("Failed to properly decode JSON string: " <> stringify fooNestedBarJsonNull)
 
     testFullCases :: Test
     testFullCases = do
       test "Json should decode to FooNested" do
         case decodeJson fooNestedFullJson of
-          Right (FooNested { bar: Just [1], baz: true }) -> pure unit
+          Right (FooNested { bar: Just [ 1 ], baz: true }) -> pure unit
           _ -> failure ("Failed to properly decode JSON string: " <> stringify fooNestedFullJson)
 
       test "Json should decode to FooNested'" do
         case decodeJson fooNestedFullJson of
-          Right (FooNested { bar: Just [1], baz: true }) -> pure unit
+          Right (FooNested { bar: Just [ 1 ], baz: true }) -> pure unit
           _ -> failure ("Failed to properly decode JSON string: " <> stringify fooNestedFullJson)
 
   test "Test that decoding custom record is pure unitful" do
@@ -338,17 +340,16 @@ nonEmptyCheck = do
         Left err ->
           false <?> printJsonDecodeError err
 
-
   test "Test EncodeJson/DecodeJson on NonEmptyString" do
     quickCheck \(x :: NonEmptyString) ->
       case decodeJson (encodeJson x) of
         Right decoded ->
           decoded == x
             <?>
-              (  " x = "
-              <> NonEmptyString.toString x
-              <> ", decoded = "
-              <> NonEmptyString.toString decoded
+              ( " x = "
+                  <> NonEmptyString.toString x
+                  <> ", decoded = "
+                  <> NonEmptyString.toString decoded
               )
         Left err ->
           false <?> printJsonDecodeError err


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
