### PR TITLE
Add optional custom ctor via voidable sum pattern

### DIFF
--- a/src/Data/Argonaut/Decode.purs
+++ b/src/Data/Argonaut/Decode.purs
@@ -10,10 +10,10 @@ import Prelude
 
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
 import Data.Argonaut.Decode.Combinators (getField, getFieldOptional, getFieldOptional', defaultField, (.:), (.:!), (.:?), (.!=))
-import Data.Argonaut.Decode.Error (JsonDecodeError(..), printJsonDecodeError)
+import Data.Argonaut.Decode.Error (JsonDecodeError'(..), printJsonDecodeError')
 import Data.Argonaut.Decode.Parser (parseJson)
 import Data.Either (Either)
 
 -- | Parse and decode a json in one step.
-fromJsonString :: forall json. DecodeJson json => String -> Either JsonDecodeError json
+fromJsonString :: forall customErr json. DecodeJson json => String -> Either (JsonDecodeError' customErr) json
 fromJsonString = parseJson >=> decodeJson

--- a/src/Data/Argonaut/Decode/Class.purs
+++ b/src/Data/Argonaut/Decode/Class.purs
@@ -3,7 +3,7 @@ module Data.Argonaut.Decode.Class where
 import Data.Argonaut.Decode.Decoders
 
 import Data.Argonaut.Core (Json, toObject)
-import Data.Argonaut.Decode.Error (JsonDecodeError(..))
+import Data.Argonaut.Decode.Error (JsonDecodeError'(..))
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
@@ -26,7 +26,7 @@ import Record as Record
 import Type.Proxy (Proxy(..))
 
 class DecodeJson a where
-  decodeJson :: Json -> Either JsonDecodeError a
+  decodeJson :: forall customErr. Json -> Either (JsonDecodeError' customErr) a
 
 instance decodeIdentity :: DecodeJson a => DecodeJson (Identity a) where
   decodeJson = decodeIdentity decodeJson
@@ -105,7 +105,7 @@ instance decodeRecord ::
       Nothing -> Left $ TypeMismatch "Object"
 
 class GDecodeJson (row :: Row Type) (list :: RL.RowList Type) | list -> row where
-  gDecodeJson :: forall proxy. FO.Object Json -> proxy list -> Either JsonDecodeError (Record row)
+  gDecodeJson :: forall customErr proxy. FO.Object Json -> proxy list -> Either (JsonDecodeError' customErr) (Record row)
 
 instance gDecodeJsonNil :: GDecodeJson () RL.Nil where
   gDecodeJson _ _ = Right {}
@@ -134,7 +134,7 @@ instance gDecodeJsonCons ::
         Left $ AtKey fieldName MissingValue
 
 class DecodeJsonField a where
-  decodeJsonField :: Maybe Json -> Maybe (Either JsonDecodeError a)
+  decodeJsonField :: forall customErr. Maybe Json -> Maybe (Either (JsonDecodeError' customErr) a)
 
 instance decodeFieldMaybe ::
   DecodeJson a =>

--- a/src/Data/Argonaut/Decode/Combinators.purs
+++ b/src/Data/Argonaut/Decode/Combinators.purs
@@ -12,7 +12,7 @@ module Data.Argonaut.Decode.Combinators
 import Prelude
 
 import Data.Argonaut.Core (Json)
-import Data.Argonaut.Decode.Error (JsonDecodeError)
+import Data.Argonaut.Decode.Error (JsonDecodeError')
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
 import Data.Either (Either)
 import Data.Maybe (Maybe, fromMaybe)
@@ -23,7 +23,7 @@ import Data.Argonaut.Decode.Decoders as Decoders
 -- |
 -- | Use this accessor if the key and value *must* be present in your object.
 -- | If the key and value are optional, use `getFieldOptional'` (`.:?`) instead.
-getField :: forall a. DecodeJson a => FO.Object Json -> String -> Either JsonDecodeError a
+getField :: forall customErr a. DecodeJson a => FO.Object Json -> String -> Either (JsonDecodeError' customErr) a
 getField = Decoders.getField decodeJson
 
 infix 7 getField as .:
@@ -35,7 +35,7 @@ infix 7 getField as .:
 -- |
 -- | Use this accessor if the key and value are optional in your object.
 -- | If the key and value are mandatory, use `getField` (`.:`) instead.
-getFieldOptional' :: forall a. DecodeJson a => FO.Object Json -> String -> Either JsonDecodeError (Maybe a)
+getFieldOptional' :: forall customErr a. DecodeJson a => FO.Object Json -> String -> Either (JsonDecodeError' customErr) (Maybe a)
 getFieldOptional' = Decoders.getFieldOptional' decodeJson
 
 infix 7 getFieldOptional' as .:?
@@ -48,7 +48,7 @@ infix 7 getFieldOptional' as .:?
 -- | This function will treat `null` as a value and attempt to decode it into your desired type.
 -- | If you would like to treat `null` values the same as absent values, use
 -- | `getFieldOptional'` (`.:?`) instead.
-getFieldOptional :: forall a. DecodeJson a => FO.Object Json -> String -> Either JsonDecodeError (Maybe a)
+getFieldOptional :: forall customErr a. DecodeJson a => FO.Object Json -> String -> Either (JsonDecodeError' customErr) (Maybe a)
 getFieldOptional = Decoders.getFieldOptional decodeJson
 
 infix 7 getFieldOptional as .:!
@@ -72,7 +72,7 @@ infix 7 getFieldOptional as .:!
 -- |     baz <- x .:? "baz" .!= false -- optional field with default value of `false`
 -- |     pure $ MyType { foo, bar, baz }
 -- | ```
-defaultField :: forall a. Either JsonDecodeError (Maybe a) -> a -> Either JsonDecodeError a
+defaultField :: forall customErr a. Either (JsonDecodeError' customErr) (Maybe a) -> a -> Either (JsonDecodeError' customErr) a
 defaultField parser default = fromMaybe default <$> parser
 
 infix 6 defaultField as .!=

--- a/src/Data/Argonaut/Decode/Error.purs
+++ b/src/Data/Argonaut/Decode/Error.purs
@@ -8,19 +8,22 @@ import Data.Argonaut.Core (Json, stringify)
 import Data.Generic.Rep (class Generic)
 
 -- | Error type for failures while decoding.
-data JsonDecodeError
+data JsonDecodeError' a
   = TypeMismatch String
   | UnexpectedValue Json
-  | AtIndex Int JsonDecodeError
-  | AtKey String JsonDecodeError
-  | Named String JsonDecodeError
+  | AtIndex Int (JsonDecodeError' a)
+  | AtKey String (JsonDecodeError' a)
+  | Named String (JsonDecodeError' a)
   | MissingValue
+  | Custom a
 
-derive instance eqJsonDecodeError :: Eq JsonDecodeError
-derive instance ordJsonDecodeError :: Ord JsonDecodeError
-derive instance genericJsonDecodeError :: Generic JsonDecodeError _
+type JsonDecodeError = JsonDecodeError' Void
 
-instance showJsonDecodeError :: Show JsonDecodeError where
+derive instance eqJsonDecodeError :: Eq a => Eq (JsonDecodeError' a)
+derive instance ordJsonDecodeError :: Ord a => Ord (JsonDecodeError' a)
+derive instance genericJsonDecodeError :: Generic (JsonDecodeError' a) _
+
+instance showJsonDecodeError :: Show a => Show (JsonDecodeError' a) where
   show = case _ of
     TypeMismatch s -> "(TypeMismatch " <> show s <> ")"
     UnexpectedValue j -> "(UnexpectedValue " <> stringify j <> ")"
@@ -28,10 +31,14 @@ instance showJsonDecodeError :: Show JsonDecodeError where
     AtKey k e -> "(AtKey " <> show k <> " " <> show e <> ")"
     Named s e -> "(Named " <> show s <> " " <> show e <> ")"
     MissingValue -> "MissingValue"
+    Custom a -> "(Custom" <> show a <> ")"
 
 -- | Prints a `JsonDecodeError` as a readable error message.
 printJsonDecodeError :: JsonDecodeError -> String
-printJsonDecodeError err =
+printJsonDecodeError = printJsonDecodeError' absurd
+
+printJsonDecodeError' :: forall a. (a -> String) -> JsonDecodeError' a -> String
+printJsonDecodeError' printCustomCtor err =
   "An error occurred while decoding a JSON value:\n" <> go err
   where
   go = case _ of
@@ -41,3 +48,4 @@ printJsonDecodeError err =
     AtKey key inner -> "  At object key \'" <> key <> "\':\n" <> go inner
     Named name inner -> "  Under '" <> name <> "':\n" <> go inner
     MissingValue -> "  No value was found."
+    Custom a -> printCustomCtor a

--- a/src/Data/Argonaut/Decode/Parser.purs
+++ b/src/Data/Argonaut/Decode/Parser.purs
@@ -3,12 +3,12 @@ module Data.Argonaut.Decode.Parser where
 import Prelude
 
 import Data.Argonaut.Core (Json)
-import Data.Argonaut.Decode.Error (JsonDecodeError(..))
+import Data.Argonaut.Decode.Error (JsonDecodeError'(..))
 import Data.Argonaut.Parser (jsonParser)
 import Data.Bifunctor (lmap)
 import Data.Either (Either)
 
 -- | Attempt to parse a string as `Json`, failing with a typed error if the
 -- | JSON string is malformed.
-parseJson :: String -> Either JsonDecodeError Json
+parseJson :: forall customErr. String -> Either (JsonDecodeError' customErr) Json
 parseJson = lmap (\_ -> TypeMismatch "JSON") <<< jsonParser


### PR DESCRIPTION
**Description of the change**

Fixes #85, except not quite... `Void` doesn't have an `Eq` instance, so neither does `JsonDecodeError'`. Thus, the test won't compile. Moreover, I'm not sure `Void` should have an Eq instance. While we could update the test to not use `==`, will this have implications for the rest of the ecosystem that'd we want?

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
