### PR TITLE
replace `"value"` with `"contents"` for Aeson compatibility

### DIFF
--- a/src/Data/Argonaut/Decode/Decoders.purs
+++ b/src/Data/Argonaut/Decode/Decoders.purs
@@ -66,7 +66,7 @@ decodeEither
 decodeEither decoderA decoderB json =
   lmap (Named "Either") $ decodeJObject json >>= \obj -> do
     tag <- note (AtKey "tag" MissingValue) $ FO.lookup "tag" obj
-    val <- note (AtKey "value" MissingValue) $ FO.lookup "value" obj
+    val <- note (AtKey "contents" MissingValue) $ FO.lookup "contents" obj
     case toString tag of
       Just "Right" -> Right <$> decoderB val
       Just "Left" -> Left <$> decoderA val

--- a/src/Data/Argonaut/Encode/Encoders.purs
+++ b/src/Data/Argonaut/Encode/Encoders.purs
@@ -42,7 +42,7 @@ encodeEither encoderA encoderB = either (obj encoderA "Left") (obj encoderB "Rig
   obj encoder tag x =
     fromObject
       $ FO.fromFoldable
-      $ Tuple "tag" (fromString tag) : Tuple "value" (encoder x) : Nil
+      $ Tuple "tag" (fromString tag) : Tuple "contents" (encoder x) : Nil
 
 encodeUnit :: Unit -> Json
 encodeUnit = const jsonNull


### PR DESCRIPTION
**Description of the change**

Suggestion: https://github.com/purescript-contrib/purescript-argonaut-codecs/issues/115

Feedback appreciated

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
